### PR TITLE
Fix community issues, modernize toolchain, drop permission_handler (v1.0.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+## 1.0.5
+
+* **Removed the `permission_handler` dependency** from the plugin. It was unused
+  by the library and only forced version conflicts on consumers (#36). Apps that
+  still need it can add it directly.
+* **Fixed external/removable storage support** (#41). `makeDirectoryPath` no
+  longer assumes a `primary` volume, so SD-card and USB tree URIs (e.g.
+  `.../tree/ABB8-7BD7%3A...`) are parsed correctly instead of throwing
+  `RangeError`.
+* **Fixed `getDirectoryPermission`** (#8, #27, #34). The permission the user
+  actually grants is now adopted regardless of `isDynamic`, and persisted
+  permissions are matched against the real granted URIs — so `isDynamic: false`
+  works and access is remembered across app restarts instead of re-prompting
+  every launch.
+  * Behavior change: `isDynamic: false` no longer rejects a selection that does
+    not exactly equal the requested directory (that check never worked and
+    always returned `false`); it now adopts the granted directory.
+* **Added binary-safe file reading** for non-media files on Android 13+ (#24).
+  New `Saf.getFilesUri()` returns content URIs and `Saf.getDocumentContentAsBytes()`
+  reads their raw bytes, avoiding the `PathAccessException` you get from reading
+  absolute paths through `dart:io`.
+* Modernized the Android toolchain: Android Gradle Plugin 8.9.1, Kotlin 2.1.0,
+  `compileSdk` 35, `minSdk` 21, coroutines 1.9.0 (fixes #37-class build errors).
+* Bumped `flutter_lints` to `^5.0.0`.
+
 ## 1.0.4
 
 * Minor fixes and improvements

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,14 +2,14 @@ group 'com.ivehement.saf'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    ext.kotlin_version = '2.1.0'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.1'
+        classpath 'com.android.tools.build:gradle:8.9.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -26,15 +26,15 @@ apply plugin: 'kotlin-android'
 
 android {
     namespace 'com.ivehement.saf'
-    compileSdkVersion 33
+    compileSdk 35
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '11'
     }
 
     sourceSets {
@@ -42,15 +42,15 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 21
     }
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
     /// Allow usage of `CoroutineScope` to run heavy
     // computation and queries outside the Main (UI) Thread
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.2"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0"
     implementation 'androidx.documentfile:documentfile:1.0.1'
 }

--- a/android/src/main/kotlin/com/ivehement/saf/api/DocumentFileApi.kt
+++ b/android/src/main/kotlin/com/ivehement/saf/api/DocumentFileApi.kt
@@ -84,6 +84,11 @@ internal class DocumentFileApi(private val plugin: SafPlugin) :
           result.success(util?.getExternalFilesDirPath())
         }
       }
+      READ_DOCUMENT_BYTES -> {
+        if (Build.VERSION.SDK_INT >= API_21) {
+          readDocumentBytes(call, result)
+        }
+      }
       CREATE_FILE ->
           if (Build.VERSION.SDK_INT >= API_21) {
             createFile(
@@ -437,6 +442,18 @@ internal class DocumentFileApi(private val plugin: SafPlugin) :
           eventSink?.endOfStream()
         }
       }
+    }
+  }
+
+  @RequiresApi(API_21)
+  private fun readDocumentBytes(call: MethodCall, result: MethodChannel.Result) {
+    try {
+      val uri = Uri.parse(call.argument<String>("uri")!!)
+      val bytes = plugin.context.contentResolver.openInputStream(uri)?.use { it.readBytes() }
+      result.success(bytes)
+    } catch (e: Exception) {
+      Log.e("READ_DOCUMENT_BYTES_EXCEPTION", e.message ?: e.toString())
+      result.success(null)
     }
   }
 

--- a/android/src/main/kotlin/com/ivehement/saf/api/utils/DocumentConstant.kt
+++ b/android/src/main/kotlin/com/ivehement/saf/api/utils/DocumentConstant.kt
@@ -22,6 +22,7 @@ const val PERSISTED_URI_PERMISSIONS = "persistedUriPermissions"
 const val RELEASE_PERSISTABLE_URI_PERMISSION =
   "releasePersistableUriPermission"
 const val CREATE_FILE = "createFile"
+const val READ_DOCUMENT_BYTES = "readDocumentBytes"
 const val FROM_TREE_URI = "fromTreeUri"
 const val CAN_WRITE = "canWrite"
 const val CAN_READ = "canRead"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -116,26 +116,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
@@ -145,7 +145,7 @@ packages:
     source: hosted
     version: "1.9.1"
   permission_handler:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: permission_handler
       sha256: bc917da36261b00137bbc8896bf1482169cd76f866282368948f032c8c1caae1
@@ -206,7 +206,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.3+4"
+    version: "1.0.5"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -256,10 +256,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.10"
   vector_math:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -32,6 +32,7 @@ dependencies:
     sdk: flutter
   saf:
     path: ../
+  permission_handler: ^12.0.1
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/lib/src/storage_access_framework/api.dart
+++ b/lib/src/storage_access_framework/api.dart
@@ -28,16 +28,57 @@ String makeUriString({String path = "", bool isTreeUri = false}) {
 }
 
 /// Convert URI String into Directory path
+///
+/// Works for the primary volume as well as removable/external volumes
+/// (SD card, USB) whose tree URIs use a volume id instead of `primary`,
+/// e.g. `content://com.android.externalstorage.documents/tree/ABB8-7BD7%3APRIVATE`.
+/// The path portion always follows the first `%3A` (URL-encoded `:`) that
+/// separates the volume id from the relative path.
 String makeDirectoryPath(String uriString) {
-  String directoryPathUriString = uriString.split("primary%3A")[1];
-  String directoryPath =
-      directoryPathUriString.replaceAll("%2F", "/").replaceAll("%20", " ");
-  return directoryPath;
+  const marker = "%3A";
+  final markerIndex = uriString.indexOf(marker);
+
+  /// No volume separator found: return the decoded input unchanged rather
+  /// than crashing with a RangeError.
+  final directoryPathUriString =
+      markerIndex == -1 ? uriString : uriString.substring(markerIndex + marker.length);
+  return directoryPathUriString.replaceAll("%2F", "/").replaceAll("%20", " ");
 }
 
 /// Create a name Alias for Directory path e.g. Android/media/matrix -> Android_media_matrix
 String makeDirectoryPathToName(String path) {
   return path.replaceAll("/", "_");
+}
+
+/// Normalize a directory path for comparison by stripping the common
+/// external-storage roots and surrounding slashes.
+///
+/// A filesystem path (`/storage/emulated/0/MyApp`) and the volume-relative
+/// path a SAF tree URI decodes to (`MyApp`) should be treated as the same
+/// directory when deciding whether a persisted permission can be reused.
+String normalizeDirectoryPath(String path) {
+  var p = path.trim();
+  for (final root in const [
+    "/storage/emulated/0/",
+    "/storage/self/primary/",
+    "/sdcard/",
+  ]) {
+    if (p.startsWith(root)) {
+      p = p.substring(root.length);
+      break;
+    }
+  }
+  return p.replaceAll(RegExp(r"^/+"), "").replaceAll(RegExp(r"/+$"), "");
+}
+
+/// Whether two directory paths refer to the same directory, tolerating the
+/// volume-root prefix differences between a filesystem path and a SAF path.
+bool isSameDirectoryPath(String a, String b) {
+  final na = normalizeDirectoryPath(a);
+  final nb = normalizeDirectoryPath(b);
+  if (na == nb) return true;
+  if (na.isEmpty || nb.isEmpty) return false;
+  return na.endsWith("/$nb") || nb.endsWith("/$na");
 }
 
 /// Start Activity Action: Allow the user to pick a directory subtree.
@@ -552,6 +593,22 @@ Future<DocumentFile?> copy(Uri uri, Uri destination) async {
   if (duplicatedFile == null) return null;
 
   return DocumentFile.fromMap(duplicatedFile);
+}
+
+/// Read the full binary content of a document `uri`.
+///
+/// Unlike [getDocumentContent] (which streams text line-by-line and is lossy
+/// for binary data and trailing newlines), this returns the raw bytes and
+/// works for any file type — including non-media files on Android 13+ that
+/// cannot be read through a `dart:io` `File` because of scoped storage. (#24)
+Future<Uint8List?> getDocumentContentAsBytes(Uri uri) async {
+  const kReadDocumentBytes = 'readDocumentBytes';
+  const kUri = 'uri';
+
+  final args = <String, String>{kUri: '$uri'};
+
+  return await kDocumentFileChannel.invokeMethod<Uint8List>(
+      kReadDocumentBytes, args);
 }
 
 /// Get content of a given document `uri`

--- a/lib/src/storage_access_framework/saf.dart
+++ b/lib/src/storage_access_framework/saf.dart
@@ -1,4 +1,7 @@
+import 'dart:typed_data';
+
 import 'package:saf/src/storage_access_framework/api.dart';
+import 'package:saf/src/storage_access_framework/api.dart' as api;
 import 'package:saf/src/channels.dart';
 
 /// Extend the native SAF api funtionality and add some of the real Use case methods for Applicatoions
@@ -12,13 +15,21 @@ class Saf {
   /// Request the user for access to [Directory Permission], if access hasn't already
   /// been grant access before.
   ///
+  /// When [isDynamic] is `false` the picker opens at the directory this instance
+  /// was created for; when `true` it simply lets the user pick any directory.
+  /// In both cases the permission the user actually grants is adopted, so a
+  /// previously granted directory is reused on later launches instead of
+  /// re-prompting every time.
+  ///
   /// Returns [bool].
   Future<bool?> getDirectoryPermission(
       {bool grantWritePermission = true, bool isDynamic = false}) async {
     try {
-      /// Check if user has already Permission Granted
-      var isGranted = await isPersistedPermissionDirectoryFor(_uriString);
-      if (isGranted != null && isGranted) return true;
+      /// Reuse an existing persisted permission for this directory if present.
+      /// Matching is done against the URIs the OS actually granted (not a
+      /// reconstructed string), which is why access is now remembered across
+      /// app restarts. (#27, #34)
+      if (await _adoptPersistedPermission()) return true;
 
       const kOpenDocumentTree = 'openDocumentTree';
       const kGrantWritePermission = 'grantWritePermission';
@@ -36,19 +47,38 @@ class Saf {
       /// Get the URI of user selected Directory path
       final selectedDirectoryUri = await kDocumentFileChannel
           .invokeMethod<String?>(kOpenDocumentTree, args);
-      if (isDynamic) {
-        _uriString = selectedDirectoryUri;
-        _directory = makeDirectoryPath(_uriString!);
-      }
-      if (!isDynamic && selectedDirectoryUri != _uriString) {
-        releasePersistableUriPermission(selectedDirectoryUri);
-        return false;
-      }
+
+      /// User dismissed the picker without choosing anything.
+      if (selectedDirectoryUri == null) return false;
+
+      /// Adopt the directory the user actually granted. Previously this only
+      /// happened for `isDynamic: true`, so `isDynamic: false` always compared
+      /// the granted URI against a reconstructed one that never matched, then
+      /// released the grant and returned false. (#8)
+      _uriString = selectedDirectoryUri;
+      _directory = makeDirectoryPath(selectedDirectoryUri);
 
       return true;
     } catch (e) {
       return null;
     }
+  }
+
+  /// If the OS already holds a persisted permission whose directory matches
+  /// [_directory], adopt its (real) URI and return `true`.
+  Future<bool> _adoptPersistedPermission() async {
+    final uriPermissions = await persistedUriPermissions();
+    if (uriPermissions == null) return false;
+
+    for (final uriPermission in uriPermissions) {
+      final uriString = uriPermission.uri.toString();
+      if (isSameDirectoryPath(makeDirectoryPath(uriString), _directory)) {
+        _uriString = uriString;
+        _directory = makeDirectoryPath(uriString);
+        return true;
+      }
+    }
+    return false;
   }
 
   /// Returns an `List<String>` with all persisted [Directory]
@@ -66,6 +96,25 @@ class Saf {
     }
     return uriStrings;
   }
+
+  /// Returns the content `URI`s of the files inside the granted directory.
+  ///
+  /// Pass one of these URIs to [getDocumentContentAsBytes] to read a file's
+  /// bytes. This is the SAF-correct way to read non-media files on Android 11+,
+  /// where reading the absolute paths from [getFilesPath] through `dart:io`
+  /// fails with a permission error. (#24)
+  Future<List<String>?> getFilesUri({String fileType = "any"}) async {
+    if (_uriString == null) return null;
+    return api.getFilesUri(_uriString!, fileType: fileType);
+  }
+
+  /// Read the full binary content of a file, given its content [uriString]
+  /// (as returned by [getFilesUri]).
+  ///
+  /// Returns the raw bytes for any file type — including non-media files on
+  /// Android 13+ that cannot be read via a `dart:io` `File`. (#24)
+  static Future<Uint8List?> getDocumentContentAsBytes(String uriString) =>
+      api.getDocumentContentAsBytes(Uri.parse(uriString));
 
   /// Equivalent to `DocumentsContract.buildDocumentUriUsingTree` and
   /// here it decode URI's to full Path

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,23 +1,22 @@
 name: saf
 description: Flutter plugin that leverages Storage Access Framework (SAF) API to get access and perform the operations on files and folders.
-homepage: https://github.com/ivehement/saf
-repository: https://github.com/ivehement/saf
-issue_tracker: https://github.com/ivehement/saf/issues
-version: 1.0.4
+homepage: https://github.com/jvoltci/saf
+repository: https://github.com/jvoltci/saf
+issue_tracker: https://github.com/jvoltci/saf/issues
+version: 1.0.5
 
 environment:
   sdk: ">=2.16.1 <4.0.0"
   flutter: ">=2.5.0"
 
 dependencies:
-  permission_handler: ^12.0.1
   flutter:
     sdk: flutter
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^1.0.0
+  flutter_lints: ^5.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/test/saf_test.dart
+++ b/test/saf_test.dart
@@ -1,23 +1,68 @@
-// import 'package:flutter/services.dart';
-// import 'package:flutter_test/flutter_test.dart';
-// import 'package:saf/saf.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:saf/src/storage_access_framework/api.dart';
 
-// void main() {
-//   const MethodChannel channel = MethodChannel('saf');
+void main() {
+  group('makeDirectoryPath', () {
+    test('decodes a primary-volume tree URI', () {
+      final uri =
+          'content://com.android.externalstorage.documents/tree/primary%3AMyApp';
+      expect(makeDirectoryPath(uri), 'MyApp');
+    });
 
-//   TestWidgetsFlutterBinding.ensureInitialized();
+    test('decodes a nested primary-volume path', () {
+      final uri =
+          'content://com.android.externalstorage.documents/tree/primary%3AAndroid%2Fmedia%2Fmatrix';
+      expect(makeDirectoryPath(uri), 'Android/media/matrix');
+    });
 
-//   setUp(() {
-//     channel.setMockMethodCallHandler((MethodCall methodCall) async {
-//       return '42';
-//     });
-//   });
+    // Regression for #41: external/removable volumes have a volume id
+    // instead of `primary`, which used to throw `RangeError`.
+    test('decodes an external (SD/USB) volume URI without throwing', () {
+      final uri =
+          'content://com.android.externalstorage.documents/tree/ABB8-7BD7%3APRIVATE%2FSONY';
+      expect(makeDirectoryPath(uri), 'PRIVATE/SONY');
+    });
 
-//   tearDown(() {
-//     channel.setMockMethodCallHandler(null);
-//   });
+    test('handles an external volume URI with an empty path', () {
+      final uri =
+          'content://com.android.externalstorage.documents/tree/00D0-08B0%3A';
+      expect(makeDirectoryPath(uri), '');
+    });
 
-//   test('getPlatformVersion', () async {
-//     expect(await Saf.platformVersion, '42');
-//   });
-// }
+    test('returns the decoded input when no volume marker is present', () {
+      expect(makeDirectoryPath('MyApp'), 'MyApp');
+    });
+  });
+
+  group('normalizeDirectoryPath', () {
+    test('strips the primary external-storage root', () {
+      expect(normalizeDirectoryPath('/storage/emulated/0/MyApp'), 'MyApp');
+    });
+
+    test('strips the sdcard root and surrounding slashes', () {
+      expect(normalizeDirectoryPath('/sdcard/MyApp/'), 'MyApp');
+    });
+
+    test('leaves an already-relative path untouched', () {
+      expect(normalizeDirectoryPath('MyApp'), 'MyApp');
+    });
+  });
+
+  group('isSameDirectoryPath', () {
+    test('matches a filesystem path against its SAF-relative form', () {
+      expect(isSameDirectoryPath('/storage/emulated/0/MyApp', 'MyApp'), isTrue);
+    });
+
+    test('matches identical relative paths', () {
+      expect(isSameDirectoryPath('Android/media', 'Android/media'), isTrue);
+    });
+
+    test('does not match different directories', () {
+      expect(isSameDirectoryPath('MyApp', 'OtherApp'), isFalse);
+    });
+
+    test('does not match on a partial segment', () {
+      expect(isSameDirectoryPath('App', 'MyApp'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Release **v1.0.5** — fixes the top community issues and modernizes the Android toolchain.

## Fixes
- **Closes #36** — remove the unused `permission_handler` dependency from the library (it was never imported in `lib/`, only forced version conflicts on consumers). Moved to the example.
- **Closes #37** — namespace was already added in 1.0.4; toolchain bump (below) hardens against the AGP build error.
- **Addresses #41** — `makeDirectoryPath` no longer assumes a `primary` volume, so SD-card / USB tree URIs (e.g. `.../tree/ABB8-7BD7%3A...`) parse instead of throwing `RangeError`.
- **Addresses #8 / #27 / #34** — `getDirectoryPermission` adopts the actually-granted URI regardless of `isDynamic`, and reuses persisted permissions matched by real URI, so `isDynamic:false` works and access survives app restarts.
  - Behavior change: `isDynamic:false` no longer rejects a selection that doesn't exactly equal the requested directory (that check never worked and always returned `false`).
- **Addresses #24** — new `Saf.getFilesUri()` + `Saf.getDocumentContentAsBytes()` + native `readDocumentBytes` for binary-safe reads of non-media files on Android 13+.

## Toolchain
AGP 8.9.1, Kotlin 2.1.0, compileSdk 35, minSdk 21, coroutines 1.9.0, `flutter_lints ^5.0.0`. Repository URLs repointed to jvoltci/saf.

## Verification
`flutter analyze` (clean), `flutter test` (12/12 incl. #41 regression), `flutter build apk --debug` on the example (builds).

## Needs on-device testing before publish
- #8/#27/#34: `isDynamic:false` + no re-prompt after restart
- #41: pick an external SD/USB volume
- #24: read a non-media file (e.g. .vcf) via `getDocumentContentAsBytes`

The `#41/#8/#27/#34/#24` items are marked *Addresses* (not auto-close) pending on-device confirmation.