### PR TITLE
Docs site + CI, README rebrand, polish to pana 150/150 (v1.0.6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  analyze-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - name: Install dependencies
+        run: flutter pub get
+      - name: Verify formatting
+        run: dart format --output=none --set-exit-if-changed .
+      - name: Analyze
+        run: flutter analyze
+      - name: Run tests
+        run: flutter test

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,43 @@
+name: docs
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - name: Install dependencies
+        run: flutter pub get
+      - name: Generate API docs
+        run: dart doc --output doc/api
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: doc/api
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.0.6
+
+* Added a documentation site (dartdoc) published to GitHub Pages at
+  https://jvoltci.github.io/saf/, and pointed the package homepage there
+  (replaces the removed wiki links).
+* Added GitHub Actions: CI (format + analyze + test) and docs deployment.
+* Documentation and lint polish: `flutter analyze` and `dart doc` are now clean
+  (0 issues, 0 warnings); example uses `debugPrint`.
+
 ## 1.0.5
 
 * **Removed the `permission_handler` dependency** from the plugin. It was unused

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-![saf](https://github.com/ivehement/saf/blob/master/example/screenshots/saf_banner.png?raw=true)
+![saf](https://github.com/jvoltci/saf/blob/master/example/screenshots/saf_banner.png?raw=true)
 <p align="center">
  <a href="https://pub.dartlang.org/packages/saf">
     <img alt="Saf" src="https://img.shields.io/pub/v/saf.svg">
   </a>
-  <a href="https://github.com/ivehement/saf/issues"><img src="https://img.shields.io/github/issues/ivehement/saf">
+  <a href="https://github.com/jvoltci/saf/issues"><img src="https://img.shields.io/github/issues/jvoltci/saf">
   </a>
-  <img src="https://img.shields.io/github/license/ivehement/saf">
-  <!-- <a href="https://github.com/ivehement/saf/actions/workflows/main.yml">
-    <img alt="CI pipeline status" src="https://github.com/ivehement/saf/actions/workflows/main.yml/badge.svg">
-  </a> -->
+  <img src="https://img.shields.io/github/license/jvoltci/saf">
+  <a href="https://github.com/jvoltci/saf/actions/workflows/ci.yml">
+    <img alt="CI pipeline status" src="https://github.com/jvoltci/saf/actions/workflows/ci.yml/badge.svg">
+  </a>
 </p>
 
 # Saf
@@ -27,7 +27,7 @@ If you have any feature that you want to see in this package, please feel free t
 
 ## Example App
 #### Android
-![Demo](https://github.com/ivehement/saf/blob/master/example/screenshots/saf_example.gif)
+![Demo](https://github.com/jvoltci/saf/blob/master/example/screenshots/saf_example.gif)
 
 ## Usage
 
@@ -58,6 +58,18 @@ bool? directoriesPath = await saf.getPersistedPermissionDirectories();
 ```dart
 
 List<String>? paths = await saf.getFilesPath(FileType.media);
+
+```
+#### Read a file's contents (works for non-media files on Android 13+)
+> On Android 11+ reading the absolute paths from `getFilesPath` through
+> `dart:io` `File` throws a `PathAccessException` for non-media files. Read the
+> file via its SAF content URI instead:
+```dart
+
+List<String>? uris = await saf.getFilesUri();
+if (uris != null && uris.isNotEmpty) {
+  Uint8List? bytes = await Saf.getDocumentContentAsBytes(uris.first);
+}
 
 ```
 #### Cache the current directory
@@ -104,21 +116,11 @@ await Saf.releasePersistedPermissions();
 ```
 
 ## Documentation
-See the **[Saf Wiki](https://github.com/ivehement/saf/wiki)** for every detail on about how to install, setup and use it.
 
-### Saf Wiki
+- **[Documentation site](https://jvoltci.github.io/saf/)** — full API reference (generated from source).
+- **[API reference](https://jvoltci.github.io/saf/saf/Saf-class.html)** — the `Saf` class and its methods.
 
-1. [Installation](https://github.com/ivehement/saf/wiki/Installation)
-2. [Setup](https://github.com/ivehement/saf/wiki/Setup)
-   * [Android](https://github.com/ivehement/saf/wiki/Setup#android)
-3. [API](https://github.com/ivehement/saf/wiki/api)
-   * [Methods](https://github.com/ivehement/saf/wiki/API#methods)
-   * [Parameters](https://github.com/ivehement/saf/wiki/API#parameters)
-   * [Filters](https://github.com/ivehement/saf/wiki/API#filters)
-4. [FAQ](https://github.com/ivehement/saf/wiki/FAQ)
-5. [Troubleshooting](https://github.com/ivehement/saf/wiki/Troubleshooting)
-
-For full usage details refer to the **[Wiki](https://github.com/ivehement/saf/wiki)** above.
+The usage examples above cover the common operations; see the docs site for the complete API.
 
 ## Getting Started
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -70,27 +70,29 @@ class _FileExplorerPageState extends State<FileExplorerPage> {
           });
 
           // Get all files recursively from the selected directory
-          print("DEBUG: Calling Saf.getFilesPathFor with directory: $selectedDirectory");
+          debugPrint(
+            "DEBUG: Calling Saf.getFilesPathFor with directory: $selectedDirectory",
+          );
           List<String>? filePaths = await Saf.getFilesPathFor(
             selectedDirectory,
             fileType: "any", // Get all file types
           );
 
-          print("DEBUG: Received filePaths: $filePaths");
-          print("DEBUG: FilePaths length: ${filePaths?.length ?? 0}");
+          debugPrint("DEBUG: Received filePaths: $filePaths");
+          debugPrint("DEBUG: FilePaths length: ${filePaths?.length ?? 0}");
 
           if (filePaths != null) {
             setState(() {
               _filePaths = filePaths;
               _isLoading = false;
             });
-            print("DEBUG: Updated UI with ${filePaths.length} files");
+            debugPrint("DEBUG: Updated UI with ${filePaths.length} files");
           } else {
             setState(() {
               _errorMessage = "No files found in the selected directory";
               _isLoading = false;
             });
-            print("DEBUG: No files found, showing error message");
+            debugPrint("DEBUG: No files found, showing error message");
           }
         } else {
           setState(() {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -148,10 +148,10 @@ packages:
     dependency: "direct main"
     description:
       name: permission_handler
-      sha256: bc917da36261b00137bbc8896bf1482169cd76f866282368948f032c8c1caae1
+      sha256: fe54465bcc62a4564c6e4db337bbaded6c0c0fa6e10487414436d163114784f6
       url: "https://pub.dev"
     source: hosted
-    version: "12.0.1"
+    version: "12.0.3"
   permission_handler_android:
     dependency: transitive
     description:
@@ -206,7 +206,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.5"
+    version: "1.0.6"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
     sdk: flutter
   saf:
     path: ../
-  permission_handler: ^12.0.1
+  permission_handler: ^12.0.3
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/lib/saf.dart
+++ b/lib/saf.dart
@@ -1,3 +1,8 @@
+/// Flutter plugin that leverages the Android Storage Access Framework (SAF)
+/// to request directory access and read, cache, and sync files and folders.
+///
+/// The main entry point is the [Saf] class. See the
+/// [project page](https://jvoltci.github.io/saf/) for usage examples.
 library saf;
 
 export './src/storage_access_framework/saf.dart';

--- a/lib/src/storage_access_framework/api.dart
+++ b/lib/src/storage_access_framework/api.dart
@@ -12,8 +12,8 @@ String makeUriString({String path = "", bool isTreeUri = false}) {
   String uri = "";
   String base =
       "content://com.android.externalstorage.documents/tree/primary%3A";
-  String documentUri = "/document/primary%3A" +
-      path.replaceAll("/", "%2F").replaceAll(" ", "%20");
+  String documentUri =
+      "/document/primary%3A${path.replaceAll("/", "%2F").replaceAll(" ", "%20")}";
   if (isTreeUri) {
     uri = base + path.replaceAll("/", "%2F").replaceAll(" ", "%20");
   } else {
@@ -40,8 +40,9 @@ String makeDirectoryPath(String uriString) {
 
   /// No volume separator found: return the decoded input unchanged rather
   /// than crashing with a RangeError.
-  final directoryPathUriString =
-      markerIndex == -1 ? uriString : uriString.substring(markerIndex + marker.length);
+  final directoryPathUriString = markerIndex == -1
+      ? uriString
+      : uriString.substring(markerIndex + marker.length);
   return directoryPathUriString.replaceAll("%2F", "/").replaceAll("%20", " ");
 }
 
@@ -131,7 +132,7 @@ Future<List<String>?> getFilesUri(String treeUriString,
   }
 }
 
-/// Get the path for App Package's [files] Directory i.e. ~/Android/data/<package-id>/files/
+/// Get the path for App Package's `files` directory, e.g. `~/Android/data/<package-id>/files/`
 Future<String?> getExternalFilesDirPath() async {
   try {
     const kGetFilesUri = "getExternalFilesDirPath";
@@ -166,12 +167,12 @@ Future<List<UriPermission>?> persistedUriPermissions() async {
 /// by `openDocumentTree` method
 ///
 /// To get the current persisted [URI]s call `persistedUriPermissions`
-Future<void> releasePersistableUriPermission(directory) async {
+Future<void> releasePersistableUriPermission(String directory) async {
   const kReleasePersistableUriPermission = 'releasePersistableUriPermission';
 
   const kUri = 'uri';
 
-  final args = <String, String>{kUri: '$directory'};
+  final args = <String, String>{kUri: directory};
 
   await kDocumentFileChannel.invokeMethod(
       kReleasePersistableUriPermission, args);

--- a/lib/src/storage_access_framework/saf.dart
+++ b/lib/src/storage_access_framework/saf.dart
@@ -12,7 +12,7 @@ class Saf {
     _uriString = makeUriString(path: _directory, isTreeUri: true);
   }
 
-  /// Request the user for access to [Directory Permission], if access hasn't already
+  /// Request the user for access to `Directory Permission`, if access hasn't already
   /// been grant access before.
   ///
   /// When [isDynamic] is `false` the picker opens at the directory this instance
@@ -84,7 +84,7 @@ class Saf {
   /// Returns an `List<String>` with all persisted [Directory]
   ///
   /// To persist an [Directory] call `getDirectoryPermission`
-  /// and to remove an persisted [URI] call `releasePersistedPermissions`
+  /// and to remove an persisted `URI` call `releasePersistedPermissions`
   static Future<List<String>?> getPersistedPermissionDirectories() async {
     var uriPermissions = await persistedUriPermissions();
 
@@ -140,7 +140,7 @@ class Saf {
     }
   }
 
-  // Request to `cache` the Granted Directory into App's Package [files] folder
+  // Request to `cache` the Granted Directory into App's Package `files` folder
   Future<List<String>?> cache({String? fileType}) async {
     try {
       const kCacheToExternalFilesDirectory = "cacheToExternalFilesDirectory";
@@ -188,7 +188,7 @@ class Saf {
     }
   }
 
-  // Request to `cache` the single files from Granted Directory into App's Package [files] folder
+  // Request to `cache` the single files from Granted Directory into App's Package `files` folder
   Future<String?> singleCache({
     required String? filePath,
     String? directory,
@@ -218,7 +218,7 @@ class Saf {
     }
   }
 
-  /// Returns `bool` after deleting files from App's Package [files] folder
+  /// Returns `bool` after deleting files from App's Package `files` folder
   /// for respective Granted Directory
   /// To cache an [Directory] call `cache`
   Future<bool?> clearCache() async {
@@ -264,16 +264,16 @@ class Saf {
 
   /// Will revoke an persistable URI
   ///
-  /// Call this when your App no longer wants the permission of an [URI] returned
+  /// Call this when your App no longer wants the permission of an `URI` returned
   /// by `getDirectoryPermission` method
   ///
-  /// To get the current persisted [URI]s call `getPersistedPermissionDirectories`
+  /// To get the current persisted `URI`s call `getPersistedPermissionDirectories`
   Future<void> releasePersistedPermission() async {
     await releasePersistableUriPermission(
         makeUriString(path: _directory, isTreeUri: true));
   }
 
-  /// Request the user for access to [Directory Permission] of User choice
+  /// Request the user for access to `Directory Permission` of User choice
   ///
   /// Returns [bool].
   static Future<bool?> getDynamicDirectoryPermission(
@@ -326,7 +326,7 @@ class Saf {
   }
 
   /// Static method for Dynamic call
-  // Request to `cache` the Granted Directory into App's Package [files] folder
+  // Request to `cache` the Granted Directory into App's Package `files` folder
   static Future<List<String>?> cacheFor(String? directory,
       {String fileType = "any"}) async {
     if (directory == null) return null;
@@ -379,7 +379,7 @@ class Saf {
   }
 
   /// Static method for Dynamic call
-  /// Returns `bool` after deleting files from App's Package [files] folder
+  /// Returns `bool` after deleting files from App's Package `files` folder
   /// for respective Granted Directory
   /// To cache an [Directory] call `cache`
   static Future<bool?> clearCacheFor(String? directory) async {
@@ -430,9 +430,9 @@ class Saf {
 
   /// Will revoke an persistable URI
   ///
-  /// Call this when your App no longer wants the permission of all the [URI]s
+  /// Call this when your App no longer wants the permission of all the `URI`s
   ///
-  /// To get the current persisted [URI]s call `getPersistedPermissionDirectories`
+  /// To get the current persisted `URI`s call `getPersistedPermissionDirectories`
   static Future<void> releasePersistedPermissions() async {
     var persistedPermissionDirectories =
         await getPersistedPermissionDirectories();
@@ -461,7 +461,7 @@ class Saf {
   /// is allowed to be write or read from SAF API's
   ///
   /// This uses the `persistedUriPermissions` method to get the List
-  /// of allowed [URI]s then will verify if the [uri] is included in
+  /// of allowed `URI`s then will verify if the `uri` is included in
   static Future<bool?> isPersistedPermissionDirectoryFor(
       String? uriString) async {
     if (uriString == null) return null;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,9 +1,10 @@
 name: saf
 description: Flutter plugin that leverages Storage Access Framework (SAF) API to get access and perform the operations on files and folders.
-homepage: https://github.com/jvoltci/saf
+homepage: https://jvoltci.github.io/saf/
 repository: https://github.com/jvoltci/saf
 issue_tracker: https://github.com/jvoltci/saf/issues
-version: 1.0.5
+documentation: https://jvoltci.github.io/saf/
+version: 1.0.6
 
 environment:
   sdk: ">=2.16.1 <4.0.0"


### PR DESCRIPTION
## Summary
Adds a documentation site + CI, reconciles the README that PR #42's squash-merge missed, and polishes the package to a **perfect pana score (150/150)**. Version → **1.0.6**.

## What's here
- **Docs site**: dartdoc generated and deployed to GitHub Pages at https://jvoltci.github.io/saf/ via a `docs` workflow. `homepage`/`documentation` point there; the dead wiki links are removed (#31).
- **CI**: `ci.yml` runs `dart format` check + `flutter analyze` + `flutter test` on push/PR (the README CI badge is enabled).
- **README reconcile**: rebrand to jvoltci + the #24 "Read a file's contents" usage section (these were in PR #42's branch but got dropped by the squash-merge, so master still showed ivehement/dead-wiki).
- **Polish**: typed `releasePersistableUriPermission(String)`, cleared every `flutter analyze` and `dart doc` warning, `print`->`debugPrint` in the example, `dart format` applied, example `permission_handler` -> ^12.0.3.

## Verification (local)
- `flutter analyze`: No issues found
- `flutter test`: 12/12
- `dart doc`: 0 warnings, 0 errors
- `dart format`: clean
- `pana`: **150/150**
- example `flutter build apk --debug`: builds

The GitHub Pages site deploys automatically once this merges to master (the `docs` workflow).